### PR TITLE
User can delete product from order

### DIFF
--- a/website/templates/order_detail.html
+++ b/website/templates/order_detail.html
@@ -21,7 +21,11 @@
       <td>{{ object.1 }}</td>
       <td>{{ product.price }}</td>
       <td>{{ object.2 }}</td>
-      <td><button class="btn btn-xs btn-danger">delete</button></td>
+      <form method="POST" action="{% url 'website:delete_product_from_order' product.id order.id %}">
+      {% csrf_token %}
+    <td>
+      <input type="submit" value="Delete" class="btn btn-xs btn-danger"></input></td>
+      </form>
       {% endfor%}
     </tr>
     {% endfor%}

--- a/website/urls.py
+++ b/website/urls.py
@@ -20,10 +20,8 @@ urlpatterns = [
     url(r'^product-categories$', views.list_product_categories, name='list_product_categories'),
     url(r'^completeorder$', views.complete_order, name='complete_order'),
     url(r'^order/(?P<order_id>[0-9]+)/$', views.order_detail, name="order_detail"), 
+    url(r'^order/deleteproduct/(?P<product_id>[0-9]+)/(?P<order_id>[0-9]+)$', views.order_detail_view.delete_product_from_order, name="delete_product_from_order"), 
     url(r'^order/$', views.no_order, name='no_order'),
     url(r'^deleteorder/$', views.delete_order, name='delete_order')
     
-
-
-
 ]

--- a/website/views/__init__.py
+++ b/website/views/__init__.py
@@ -7,7 +7,7 @@ from website.views.user_logout_view import user_logout
 from website.views.payment_type_view import add_payment_type, delete_payment_type
 from website.views.list_product_categories_view import list_product_categories
 from website.views.product_detail_view import product_detail
-from website.views.order_detail_view import order_detail
+from website.views.order_detail_view import order_detail, delete_product_from_order
 from website.views.no_order_view import no_order
 from website.views.my_account_view import my_account
 from website.views.list_my_products_view import list_my_products

--- a/website/views/order_detail_view.py
+++ b/website/views/order_detail_view.py
@@ -4,6 +4,8 @@ from website.models.order_model import Order
 from website.models.product_order_model import ProductOrder
 from website.models.product_model import Product
 from django.contrib.auth.models import User
+from django.http import HttpResponseRedirect
+
 
 def order_detail(request, order_id):
 	"""
@@ -29,3 +31,12 @@ def order_detail(request, order_id):
 
 
 	return render(request, template_name, {'order': order, "orderproducts":product_list, "total":total})
+
+def delete_product_from_order(request, product_id, order_id):
+
+	ProductOrder.objects.filter(product_id=product_id, order_id=order_id).delete()
+	return render(request, 'success.html', {"deleted_object":"Product"})
+
+
+
+


### PR DESCRIPTION
## Associated Ticket
[#6](https://github.com/solanum-tuberosums/djangazon/issues/6)

## Description 
Now a product line item in a user's shopping cart can be deleted and consequently struck from the ProductOrder table in the DB.

Still need to update the rendering of the redirect to success template after product is deleted (Blaise has recently updated this template).

## All Tests Pass
n/a